### PR TITLE
42 bug only kings can be placed into open tableaus

### DIFF
--- a/src/phasor/Deck.ts
+++ b/src/phasor/Deck.ts
@@ -51,14 +51,20 @@ export default class Deck {
     return deck;
   }
 
-  public cardChildren(card: Card): Card[] {
-    return this.cards
-      .filter(
-        (curr: Card) =>
-          curr.pile === card.pile && curr.position >= card.position
-      )
-      .sort((a: Card, b: Card) => a.position - b.position);
-  }
+/**
+ * Returns the given card and all following cards in the same pile.
+ *
+ * @param {Card} card - The reference card.
+ * @returns {Card[]} Cards in the same pile, sorted by ascending position.
+ */
+public cardChildren(card: Card): Card[] {
+  return this.cards
+    .filter(
+      (curr: Card) =>
+        curr.pile === card.pile && curr.position >= card.position
+    )
+    .sort((a: Card, b: Card) => a.position - b.position);
+}
 
   public validDraggableCard(card: Card, maxCards: number): boolean {
     const children: Card[] = this.cardChildren(card);

--- a/src/phasor/Pile.ts
+++ b/src/phasor/Pile.ts
@@ -13,7 +13,7 @@ export class Pile extends Phaser.GameObjects.Zone {
     const addHeight = TABLEAU_PILES.includes(this.pileId)
       ? STACK_OFFSET * 10
       : 0;
-    const addWidth = 0; //this.pileId === PileId.Stock ? 20 : 0;
+    const addWidth = 0;
 
     // Get position
     const position = PILE_POSITIONS[this.pileId];

--- a/src/phasor/Rules.ts
+++ b/src/phasor/Rules.ts
@@ -1,0 +1,85 @@
+import Deck from "./Deck";
+import Card from "./Card";
+import { CELL_PILES, FOUNDATION_PILES, PileId, TABLEAU_PILES } from "./constants/table";
+import { SUIT_COLOR } from "./constants/deck";
+
+/**
+ * Defines the drop rules for different pile types.
+ */
+const DROP_RULES: Record<PileId, (deck: Deck, card: Card) => boolean> = Object.fromEntries([
+    // Cell piles: Only one card can be placed, and the pile must be empty.
+    ...CELL_PILES.map(pileId => [pileId, (deck: Deck, card: Card) => {
+        const topCard = deck.topCard(pileId);
+        const dragChildren = deck.cardChildren(card);
+        return !topCard && dragChildren.length === 1;
+    }]),
+    
+    // Foundation piles: Cards must be placed in ascending order and match suit.
+    ...FOUNDATION_PILES.map(pileId => [pileId, (deck: Deck, card: Card) => {
+        const topCard = deck.topCard(pileId);
+        if (!topCard) return card.value === 1; // Only aces can be placed in an empty foundation pile.
+        return card.suit === topCard.suit && card.value === topCard.value + 1;
+    }]),
+    
+    // Tableau piles: Cards must alternate in color and be placed in descending order.
+    ...TABLEAU_PILES.map(pileId => [pileId, (deck: Deck, card: Card) => {
+        const topCard = deck.topCard(pileId);
+        const dragChildren = deck.cardChildren(card);
+        if (!topCard) return true; // Any card can be placed on an empty tableau pile.
+        return dragChildren.length > 0 && dragChildren.every((child, index) => {
+            const prevCard: Card = index === 0 ? topCard : dragChildren[index - 1];
+            return (
+                SUIT_COLOR[child.suit] !== SUIT_COLOR[prevCard.suit] && // Must be opposite colors.
+                child.value === prevCard.value - 1 // Must be in descending order.
+            );
+        });
+    }])
+]);
+
+/**
+ * Evaluates which piles a card can be dropped onto.
+ *
+ * @param {Deck} deck - The current deck state.
+ * @param {Card} card - The card being moved.
+ * @param {PileId[]} pileIds - A collection of target pile IDs.
+ * @returns {boolean[]} An array indicating whether each pile allows the drop, in the same order.
+ */
+export function evaluateDropPiles(deck: Deck, card: Card, pileIds: PileId[]): boolean[] {
+    return pileIds.map(pileId => DROP_RULES[pileId]?.(deck, card) ?? false);
+}
+
+/**
+ * Retrieves only the piles where a card can be legally dropped.
+ *
+ * @param {Deck} deck - The current deck state.
+ * @param {Card} card - The card being moved.
+ * @param {PileId[]} pileIds - A collection of target pile IDs.
+ * @returns {PileId[]} An array of valid pile IDs where the card can be dropped.
+ */
+export function getValidDropPiles(deck: Deck, card: Card, pileIds: PileId[]): PileId[] {
+    return pileIds.filter(pileId => DROP_RULES[pileId]?.(deck, card) ?? false);
+}
+
+/**
+ * Computes the new placements for a set of cards after a move.
+ *
+ * @param {Deck} deck - The current deck state.
+ * @param {Card[]} cards - The cards being moved.
+ * @param {PileId} pileId - The target pile ID.
+ * @returns {Array<{ pileId: PileId; position: number }>} The new positions of the moved cards.
+ */
+export function getUpdatedCardPlacements(
+    deck: Deck,
+    cards: Card[],
+    pileId: PileId
+): Array<{ pileId: PileId; position: number }> {
+    // Get the top card in the target pile
+    const topCard = deck.topCard(pileId);
+
+    // Calculate new positions
+    const basePosition = topCard ? topCard.position + 1 : 0;
+    return cards.map((_, index) => ({
+        pileId,
+        position: basePosition + index,
+    }));
+}

--- a/src/phasor/constants/table.ts
+++ b/src/phasor/constants/table.ts
@@ -1,6 +1,10 @@
 import { CARD_DIMENSIONS } from "./deck";
 
 /**
+ * @fileoverview Defines the constants and positions for the card piles used in the Freecell game.
+ */
+
+/**
  * Define the constants for the table.
  */
 export enum PileId {
@@ -66,9 +70,6 @@ const PILE_OFFSET = CARD_DIMENSIONS.width + 10;
  * Positions of piles on screen
  */
 export const PILE_POSITIONS: Record<PileId, Phaser.Math.Vector2> = {
-  //[PileId.Stock]: new Phaser.Math.Vector2(110, 120),
-  //[PileId.Discard]: new Phaser.Math.Vector2(110 + PILE_OFFSET + 20, 120),
-
   [PileId.Cell1]: new Phaser.Math.Vector2(80, 120),
   [PileId.Cell2]: new Phaser.Math.Vector2(80 + PILE_OFFSET, 120),
   [PileId.Cell3]: new Phaser.Math.Vector2(80 + 2 * PILE_OFFSET, 120),

--- a/src/phasor/constants/table.ts
+++ b/src/phasor/constants/table.ts
@@ -4,10 +4,10 @@ import { CARD_DIMENSIONS } from "./deck";
  * Define the constants for the table.
  */
 export enum PileId {
-  Cell1 = "Cell_1",
-  Cell2 = "Cell_2",
-  Cell3 = "Cell_3",
-  Cell4 = "Cell_4",
+  Cell1 = "CELL_1",
+  Cell2 = "CELL_2",
+  Cell3 = "CELL_3",
+  Cell4 = "CELL_4",
   Tableau1 = "TABLEAU_1",
   Tableau2 = "TABLEAU_2",
   Tableau3 = "TABLEAU_3",

--- a/src/phasor/constants/table.ts
+++ b/src/phasor/constants/table.ts
@@ -1,10 +1,6 @@
 import { CARD_DIMENSIONS } from "./deck";
 
 /**
- * @fileoverview Defines the constants and positions for the card piles used in the Freecell game.
- */
-
-/**
  * Define the constants for the table.
  */
 export enum PileId {


### PR DESCRIPTION
## Description
We've moved dropping related game logic into `src/phasor/Rules.ts`.

Additionally auto snap to foundation pile functionality has been rolled back. We will re-tackle in separate issue.

Due to drop rules clarification, any card can be dropped in empty tableau deck.

Fixes #42 

## Type of change
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

