### PR TITLE
49-bug-cards-snap-to-foundation-no-matter-position

### DIFF
--- a/src/phasor/GameState.ts
+++ b/src/phasor/GameState.ts
@@ -259,15 +259,19 @@ export default class GameState extends Phaser.Scene {
   }
 
   public snapCardToFoundation(card: Card): void {
-    // Get valid foundation pile
-    const validPiles = getValidDropPiles(this.deck, card, FOUNDATION_PILES);
-    const targetPile = validPiles[0]; // Returns undefined if no valid pile
+    // Don't snap foundation cards
+    if (FOUNDATION_PILES.includes(card.pile)) return;
+
+    // Only snap if card is at bottom of pile
+    if (this.deck.cardChildren(card).length > 1) return;
+
+    // Get the first valid foundation pile to drop into
+    const targetPile = getValidDropPiles(this.deck, card, FOUNDATION_PILES)[0];
+    if (!targetPile) return; // Exit early if no valid pile
 
     // Reposition card
-    if (targetPile) {
-      const [updatedPlacement] = getUpdatedCardPlacements(this.deck, [card], targetPile);
-      card.reposition(updatedPlacement.pileId, updatedPlacement.position);
-    }
+    const updatedPlacement = getUpdatedCardPlacements(this.deck, [card], targetPile)[0];
+    card.reposition(updatedPlacement.pileId, updatedPlacement.position);
   }
 
   public determineMaxCardsForMove(): number {


### PR DESCRIPTION
## Description
Snap feature bug fixes:
- Foundation pile cards cannot be moved via snap feature.
- Cards can only be snapped if at bottom of pile.

Fixes #49 

## Type of change
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

