### PR TITLE
57-bug-dragging-allowed-after-snapping

### DIFF
--- a/src/phasor/Deck.ts
+++ b/src/phasor/Deck.ts
@@ -54,33 +54,26 @@ export default class Deck {
   }
 
   /**
+   * Retrieves all cards in the specified pile, sorted by ascending position.
+   *
+   * @param {PileId} pile - The ID of the pile to retrieve cards from.
+   * @returns {Card[]} An array of cards in the pile, sorted by position.
+   */
+  public pileChildren(pile: PileId): Card[] {
+    return this.cards
+      .filter((curr: Card) => curr.pile === pile)
+      .sort((a: Card, b: Card) => a.position - b.position);
+  }
+
+  /**
    * Returns the given card and all following cards in the same pile.
    *
    * @param {Card} card - The reference card.
    * @returns {Card[]} Cards in the same pile, sorted by ascending position.
    */
   public cardChildren(card: Card): Card[] {
-    return this.cards
-      .filter(
-        (curr: Card) =>
-          curr.pile === card.pile && curr.position >= card.position
-      )
-      .sort((a: Card, b: Card) => a.position - b.position);
-  }
-
-  public topCard(pile: PileId): Card | null {
-    return (
-      this.cards
-        .filter((curr: Card) => curr.pile === pile)
-        .sort((a: Card, b: Card) => a.position - b.position)
-        .pop() ?? null
-    );
-  }
-
-  public countCards(pile: PileId): number {
-    return this.cards.reduce(
-      (acc: number, card: Card) => (card.pile === pile ? acc + 1 : acc),
-      0
+    return this.pileChildren(card.pile).filter(
+      (curr: Card) => curr.position >= card.position
     );
   }
 }

--- a/src/phasor/Deck.ts
+++ b/src/phasor/Deck.ts
@@ -53,45 +53,19 @@ export default class Deck {
     return deck;
   }
 
-/**
- * Returns the given card and all following cards in the same pile.
- *
- * @param {Card} card - The reference card.
- * @returns {Card[]} Cards in the same pile, sorted by ascending position.
- */
-public cardChildren(card: Card): Card[] {
-  return this.cards
-    .filter(
-      (curr: Card) =>
-        curr.pile === card.pile && curr.position >= card.position
-    )
-    .sort((a: Card, b: Card) => a.position - b.position);
-}
-
-  public validDraggableCard(card: Card, maxCards: number): boolean {
-    const children: Card[] = this.cardChildren(card);
-
-    if (children.length > maxCards) {
-      return false;
-    }
-
-    for (let i = 1; i < children.length; i++)
-    {
-      const current: Card = children[i];
-      const previous: Card = children[i-1];
-
-      if (current.value != previous.value - 1)
-      {
-        return false;
-      }
-
-      if (SUIT_COLOR[current.suit] === SUIT_COLOR[previous.suit])
-      {
-        return false;
-      }
-    }
-
-    return true;
+  /**
+   * Returns the given card and all following cards in the same pile.
+   *
+   * @param {Card} card - The reference card.
+   * @returns {Card[]} Cards in the same pile, sorted by ascending position.
+   */
+  public cardChildren(card: Card): Card[] {
+    return this.cards
+      .filter(
+        (curr: Card) =>
+          curr.pile === card.pile && curr.position >= card.position
+      )
+      .sort((a: Card, b: Card) => a.position - b.position);
   }
 
   public topCard(pile: PileId): Card | null {

--- a/src/phasor/GameState.ts
+++ b/src/phasor/GameState.ts
@@ -292,7 +292,7 @@ export default class GameState extends Phaser.Scene {
 
     // Win
     const cardsOnFoundation = FOUNDATION_PILES.reduce(
-      (acc, pile) => acc + this.deck.countCards(pile),
+      (acc, pile) => acc + this.deck.pileChildren(pile).length,
       0
     );
     if (cardsOnFoundation === 52) {

--- a/src/phasor/GameState.ts
+++ b/src/phasor/GameState.ts
@@ -4,7 +4,7 @@ import Card from "./Card";
 import Deck from "./Deck";
 import Pile from "./Pile";
 import { CardMoveCommand, CommandManager, CompositeCommand } from "./Command";
-import { getUpdatedCardPlacements, getValidDropPiles } from "./Rules";
+import { canMoveCard, getUpdatedCardPlacements, getValidDropPiles } from "./Rules";
 import { addButton } from "./UI";
 import { STACK_DRAG_OFFSET } from "./constants/deck";
 import { SCREEN_HEIGHT, SCREEN_WIDTH } from "./constants/screen";
@@ -80,7 +80,7 @@ export default class GameState extends Phaser.Scene {
       ) => {
         this.dragChildren = [];
 
-        if (gameObject instanceof Card && this.deck.validDraggableCard(gameObject, this.determineMaxCardsForMove())) {
+        if (gameObject instanceof Card && canMoveCard(this.deck, gameObject)) {
           this.dragCardStart(gameObject);
         }
       },
@@ -238,26 +238,25 @@ export default class GameState extends Phaser.Scene {
     // Get pile id of drop zone
     const pileId = dropZone.name as PileId;
 
-    // Update card positions if valid
-    if (getValidDropPiles(this.deck, card, [pileId]).some(Boolean)) {
-      const dragChildren = this.deck.cardChildren(card);
+    // No valid drops
+    if (!getValidDropPiles(this.deck, card, [pileId]).some(Boolean)) return;
 
-      const updatedPlacements = getUpdatedCardPlacements(this.deck, dragChildren, pileId);
-      
-      // Push command to execution stack
-      const dropAllCommand = new CompositeCommand(
-        ...dragChildren.map((child, index) =>
-          new CardMoveCommand(
-            child,
-            child.pile,
-            child.position,
-            updatedPlacements[index].pileId,
-            updatedPlacements[index].position
-          )
+    // Update card placement
+    const dragChildren = this.deck.cardChildren(card);
+    const updatedPlacements = getUpdatedCardPlacements(this.deck, dragChildren, pileId);
+
+    const dropAllCommand = new CompositeCommand(
+      ...dragChildren.map((child, index) =>
+        new CardMoveCommand(
+          child,
+          child.pile,
+          child.position,
+          updatedPlacements[index].pileId,
+          updatedPlacements[index].position
         )
-      );
-      this.commands.push(dropAllCommand);
-    }
+      )
+    );
+    this.commands.push(dropAllCommand);
   }
 
   public snapCardToFoundation(card: Card): void {
@@ -283,17 +282,6 @@ export default class GameState extends Phaser.Scene {
       updatedPlacement.position
     );
     this.commands.push(command);
-  }
-
-  public determineMaxCardsForMove(): number {
-    let maxCards: number = 1;
-    for (const cell of this.cellPiles) {
-      if (!this.deck.topCard(cell.pileId)) {
-        maxCards += 1;
-      }
-    }
-
-    return maxCards;
   }
 
   public update(): void {

--- a/src/phasor/Validation.ts
+++ b/src/phasor/Validation.ts
@@ -25,6 +25,12 @@ export const hasSameColor = (card1: Card, card2: Card): boolean =>
     SUIT_COLOR[card1.suit] === SUIT_COLOR[card2.suit];
 
 /**
+ * Checks if two cards have the same suit.
+ */
+export const hasSameSuit = (card1: Card, card2: Card): boolean =>
+    card1.suit === card2.suit;
+
+/**
  * Checks if two cards are in descending order.
  */
 export const isDescendingOrder = (card1: Card, card2: Card): boolean =>

--- a/src/phasor/Validation.ts
+++ b/src/phasor/Validation.ts
@@ -1,0 +1,37 @@
+import Card from "./Card";
+import { SUIT_COLOR } from "./constants/deck";
+
+/**
+ * Higher-order function to validate a sequence of cards based on multiple checks.
+ */
+export const isValidSequence = (
+    cards: Card[],
+    checks: ((card1: Card, card2: Card) => boolean)[]
+): boolean =>
+    cards.every((child, index) =>
+        index === 0 || checks.every(check => check(child, cards[index - 1]))
+    );
+
+/**
+ * Checks if two cards have alternating colors.
+ */
+export const hasAlternatingColor = (card1: Card, card2: Card): boolean =>
+    SUIT_COLOR[card1.suit] !== SUIT_COLOR[card2.suit];
+
+/**
+ * Checks if two cards have the same color.
+ */
+export const hasSameColor = (card1: Card, card2: Card): boolean =>
+    SUIT_COLOR[card1.suit] === SUIT_COLOR[card2.suit];
+
+/**
+ * Checks if two cards are in descending order.
+ */
+export const isDescendingOrder = (card1: Card, card2: Card): boolean =>
+    card1.value === card2.value - 1;
+
+/**
+ * Checks if two cards are in ascending order.
+ */
+export const isAscendingOrder = (card1: Card, card2: Card): boolean =>
+    card1.value === card2.value + 1;


### PR DESCRIPTION
## Description
- Additional drag rules which should prevent any card in the foundation pile from being drug.
- Added `Validation.ts` which helps perform checks such as `hasSameSuit` or `isAscendingOrder` on card sequence arrays.
- Added `pileChildren` which deprecates finicky `Deck` functions. (All uses has been updated)


Fixes #57 

## Type of change
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

