### PR TITLE
67-feature-decompose-multi-card-moves

### DIFF
--- a/src/phaser/deck/DeckController.ts
+++ b/src/phaser/deck/DeckController.ts
@@ -3,7 +3,7 @@ import { PileId } from "@phaser/constants/table";
 import { Deck } from "@phaser/deck/state/Deck";
 import {
   dealCards,
-  getDeckAfterCardMoves,
+  applyCardMoves,
   shuffleCards,
 } from "@phaser/deck/domain/DeckLogic";
 import { CardMoveSequence } from "@phaser/move/CardMoveSequence";
@@ -34,7 +34,7 @@ export class DeckController {
   }
 
   executeCardMoveSequence(cardMoves: CardMoveSequence) {
-    this.model = getDeckAfterCardMoves(this.model, cardMoves);
+    this.model = applyCardMoves(this.model, cardMoves);
     this.cardControllers.forEach((c, i) => c.setModel(this.model.cards[i]));
   }
 

--- a/src/phaser/deck/DeckController.ts
+++ b/src/phaser/deck/DeckController.ts
@@ -5,6 +5,7 @@ import {
   dealCards,
   applyCardMoves,
   shuffleCards,
+  setupTableauDrag,
 } from "@phaser/deck/domain/DeckLogic";
 import { CardMoveSequence } from "@phaser/move/CardMoveSequence";
 import { CardId } from "@phaser/card/domain/CardId";
@@ -55,7 +56,9 @@ export class DeckController {
   }
 
   dealCards(): void {
-    this.model = dealCards(this.model);
+    // TODO: Revert to regular deal
+    // this.model = dealCards(this.model);
+    this.model = setupTableauDrag(this.model);
     this.cardControllers.forEach((c, i) => c.setModel(this.model.cards[i]));
   }
 

--- a/src/phaser/deck/DeckController.ts
+++ b/src/phaser/deck/DeckController.ts
@@ -56,9 +56,7 @@ export class DeckController {
   }
 
   dealCards(): void {
-    // TODO: Revert to regular deal
-    // this.model = dealCards(this.model);
-    this.model = setupTableauDrag(this.model);
+    this.model = dealCards(this.model);
     this.cardControllers.forEach((c, i) => c.setModel(this.model.cards[i]));
   }
 

--- a/src/phaser/deck/DeckController.ts
+++ b/src/phaser/deck/DeckController.ts
@@ -1,7 +1,11 @@
 import { CardController } from "@phaser/card/CardController";
 import { PileId } from "@phaser/constants/table";
 import { Deck } from "@phaser/deck/state/Deck";
-import { dealCards, shuffleCards } from "@phaser/deck/domain/DeckLogic";
+import {
+  dealCards,
+  getDeckAfterCardMoves,
+  shuffleCards,
+} from "@phaser/deck/domain/DeckLogic";
 import { CardMoveSequence } from "@phaser/move/CardMoveSequence";
 import { CardId } from "@phaser/card/domain/CardId";
 
@@ -30,10 +34,24 @@ export class DeckController {
   }
 
   executeCardMoveSequence(cardMoves: CardMoveSequence) {
-    cardMoves.steps.forEach((move) => {
-      const cardController = this.findCardControllerWithId(move.card);
-      cardController?.setPilePosition(move.toPile, move.toPosition);
-    });
+    this.model = getDeckAfterCardMoves(this.model, cardMoves);
+    this.cardControllers.forEach((c, i) => c.setModel(this.model.cards[i]));
+  }
+
+  // TODO: This function is for debugging only.
+  // Please remove and replace with proper animations in the future.
+  async executeCardMoveSequenceWithDelay(
+    cardMoves: CardMoveSequence,
+    delayMs: number,
+  ) {
+    const wait = (ms: number) =>
+      new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+    for (const { card, toPile, toPosition } of cardMoves.steps) {
+      this.getCardControllerWithId(card)?.setPilePosition(toPile, toPosition);
+
+      await wait(delayMs);
+    }
   }
 
   dealCards(): void {
@@ -46,7 +64,7 @@ export class DeckController {
     this.cardControllers.forEach((c, i) => c.setModel(this.model.cards[i]));
   }
 
-  private findCardControllerWithId(cardId: CardId): CardController | undefined {
+  private getCardControllerWithId(cardId: CardId): CardController | undefined {
     return this.cardControllers.find(
       (controller) => controller.model.data.id === cardId,
     );

--- a/src/phaser/deck/domain/DeckLogic.ts
+++ b/src/phaser/deck/domain/DeckLogic.ts
@@ -4,7 +4,7 @@ import { PileId, TABLEAU_PILES } from "@phaser/constants/table";
 import { withFaceUp, withPilePosition } from "@phaser/card/domain/CardLogic";
 import { CardMoveSequence } from "@phaser/move/CardMoveSequence";
 
-export function getDeckAfterCardMoves(
+export function applyCardMoves(
   deck: Deck,
   cardMoves: CardMoveSequence,
 ): Deck {

--- a/src/phaser/deck/domain/DeckLogic.ts
+++ b/src/phaser/deck/domain/DeckLogic.ts
@@ -89,17 +89,16 @@ export function setupTableauDrag(deck: Deck): Deck {
   const spades = sorted.filter((c) => c.data.suit === Suit.Spades);
   const clubs = sorted.filter((c) => c.data.suit === Suit.Clubs);
 
-  // Build red/black stack (starts with red)
-  const redSuits = [...hearts, ...diamonds];
-  const blackSuits = [...spades, ...clubs];
-  const redFirstStack1 = buildAlternatingStack(
-    [...redSuits],
-    [...blackSuits],
-    "red",
+  // Build one stack starting with red, one with black
+  const redFirstStack = buildAlternatingStack([...hearts], [...clubs], "red");
+  const blackFirstStack = buildAlternatingStack(
+    [...spades],
+    [...diamonds],
+    "black",
   );
 
-  // Set redFirstStack1 into Tableau1
-  redFirstStack1.forEach((card, i) => {
+  // Assign stacks to Tableau1 and Tableau2
+  redFirstStack.forEach((card, i) => {
     card.state = {
       ...withFaceUp(card.state),
       pile: PileId.Tableau1,
@@ -107,8 +106,20 @@ export function setupTableauDrag(deck: Deck): Deck {
     };
   });
 
-  // Set all remaining cards to PileId.None
-  const usedIds = new Set(redFirstStack1.map((c) => c.data.id));
+  blackFirstStack.forEach((card, i) => {
+    card.state = {
+      ...withFaceUp(card.state),
+      pile: PileId.Tableau2,
+      position: i,
+    };
+  });
+
+  // Collect all used card IDs
+  const usedIds = new Set(
+    [...redFirstStack, ...blackFirstStack].map((c) => c.data.id),
+  );
+
+  // Put the remaining cards into PileId.None
   const rest = deck.cards
     .filter((c) => !usedIds.has(c.data.id))
     .map((card) => ({
@@ -121,7 +132,7 @@ export function setupTableauDrag(deck: Deck): Deck {
     }));
 
   return {
-    cards: [...redFirstStack1, ...rest],
+    cards: [...redFirstStack, ...blackFirstStack, ...rest],
   };
 }
 

--- a/src/phaser/deck/domain/DeckLogic.ts
+++ b/src/phaser/deck/domain/DeckLogic.ts
@@ -79,7 +79,8 @@ export function shuffleCards(deck: Deck, seed: number): Deck {
   };
 }
 
-// TODO remove setup TableauDrag function
+// TODO: This function is for debugging only.
+// Please remove this function or move into a test in the future.
 export function setupTableauDrag(deck: Deck): Deck {
   const sorted = [...deck.cards].sort((a, b) => b.data.rank - a.data.rank);
 
@@ -136,6 +137,8 @@ export function setupTableauDrag(deck: Deck): Deck {
   };
 }
 
+// TODO: This function is for debugging only. It's a helper for setupTableauDrag.
+// Please remove this function or move into a test in the future.
 function buildAlternatingStack(
   redSuitCards: Card[],
   blackSuitCards: Card[],

--- a/src/phaser/deck/domain/DeckLogic.ts
+++ b/src/phaser/deck/domain/DeckLogic.ts
@@ -1,7 +1,29 @@
 import { Card } from "@phaser/card/state/Card";
 import { Deck } from "@phaser/deck/state/Deck";
 import { PileId, TABLEAU_PILES } from "@phaser/constants/table";
-import { withFaceUp } from "@phaser/card/domain/CardLogic";
+import { withFaceUp, withPilePosition } from "@phaser/card/domain/CardLogic";
+import { CardMoveSequence } from "@phaser/move/CardMoveSequence";
+
+export function getDeckAfterCardMoves(
+  deck: Deck,
+  cardMoves: CardMoveSequence,
+): Deck {
+  const updatedCards = cardMoves.steps.reduce((cards, move) => {
+    return cards.map((card) => {
+      if (card.data.id !== move.card) return card;
+
+      return {
+        ...card,
+        state: withPilePosition(card.state, move.toPile, move.toPosition),
+      };
+    });
+  }, deck.cards);
+
+  return {
+    ...deck,
+    cards: updatedCards,
+  };
+}
 
 export function getCardsInPile(deck: Deck, pileId: PileId): Card[] {
   return deck.cards
@@ -13,6 +35,12 @@ export function getCardsStartingFrom(deck: Deck, target: Card): Card[] {
   return getCardsInPile(deck, target.state.pile).filter(
     (card) => card.state.position >= target.state.position,
   );
+}
+
+export function filterEmptyPiles(deck: Deck, piles: PileId[]) {
+  return piles.filter((pile) => {
+    return getCardsInPile(deck, pile).length === 0;
+  });
 }
 
 export function dealCards(deck: Deck): Deck {

--- a/src/phaser/deck/state/Deck.ts
+++ b/src/phaser/deck/state/Deck.ts
@@ -1,5 +1,4 @@
 import { Rank } from "@phaser/constants/deck";
-
 import { Card, createCard } from "@phaser/card/state/Card";
 import { Suit } from "@phaser/constants/deck";
 

--- a/src/phaser/game/domain/FreecellRules.ts
+++ b/src/phaser/game/domain/FreecellRules.ts
@@ -82,23 +82,10 @@ export function calculateMaxMoveSizeSimple(
   return (emptyCells + 1) << emptyTableaus;
 }
 
-export function calculateMinTempTableausSimple(
+export function calculateMinTempTableaus(
   moveSize: number,
   emptyCells: number,
 ): number {
-  return Math.ceil(Math.log2(moveSize / (emptyCells + 1)));
-}
-
-/**
- * Calculates the minimum empty tableau piles
- * required to temporarily store cards according to the formula:
- * `requiredTableaus >= log2(moveSize / (emptyCells + 1))`
- */
-function calculateMinTempTableaus(
-  cardMoves: CardMoveSequence,
-  emptyCells: number,
-): number {
-  const moveSize = cardMoves.steps.length;
   return Math.ceil(Math.log2(moveSize / (emptyCells + 1)));
 }
 

--- a/src/phaser/game/domain/FreecellRules.ts
+++ b/src/phaser/game/domain/FreecellRules.ts
@@ -75,11 +75,17 @@ export function calculateMaxMoveSize(
   return (emptyCells + 1) << emptyTableaus;
 }
 
-export function calculateMaxMoveSizeSimple(emptyCells: number, emptyTableaus: number): number {
+export function calculateMaxMoveSizeSimple(
+  emptyCells: number,
+  emptyTableaus: number,
+): number {
   return (emptyCells + 1) << emptyTableaus;
 }
 
-export function calculateMinTempTableausSimple(moveSize: number, emptyCells: number): number {
+export function calculateMinTempTableausSimple(
+  moveSize: number,
+  emptyCells: number,
+): number {
   return Math.ceil(Math.log2(moveSize / (emptyCells + 1)));
 }
 

--- a/src/phaser/game/domain/FreecellRules.ts
+++ b/src/phaser/game/domain/FreecellRules.ts
@@ -75,6 +75,14 @@ export function calculateMaxMoveSize(
   return (emptyCells + 1) << emptyTableaus;
 }
 
+export function calculateMaxMoveSizeSimple(emptyCells: number, emptyTableaus: number): number {
+  return (emptyCells + 1) << emptyTableaus;
+}
+
+export function calculateMinTempTableausSimple(moveSize: number, emptyCells: number): number {
+  return Math.ceil(Math.log2(moveSize / (emptyCells + 1)));
+}
+
 /**
  * Calculates the minimum empty tableau piles
  * required to temporarily store cards according to the formula:

--- a/src/phaser/game/domain/FreecellRules.ts
+++ b/src/phaser/game/domain/FreecellRules.ts
@@ -52,30 +52,7 @@ export function canMoveCard(deck: Deck, card: Card): boolean {
   return DRAG_RULES[card.state.pile]?.(deck, card) ?? false;
 }
 
-/**
- * Calculate maximum number of cards that be moved according to the formula:
- * `maxMoveSize = (emptyCells + 1) * 2^emptyTableaus`
- *
- * You can specify any piles to ignore during this calculation.
- */
 export function calculateMaxMoveSize(
-  deck: Deck,
-  pilesToIgnore: PileId[] = [],
-): number {
-  const remainingCells = CELL_PILES.filter(
-    (pile) => !pilesToIgnore.includes(pile),
-  );
-  const remainingTableaus = TABLEAU_PILES.filter(
-    (pile) => !pilesToIgnore.includes(pile),
-  );
-
-  const emptyCells = filterEmptyPiles(deck, remainingCells).length;
-  const emptyTableaus = filterEmptyPiles(deck, remainingTableaus).length;
-
-  return (emptyCells + 1) << emptyTableaus;
-}
-
-export function calculateMaxMoveSizeSimple(
   emptyCells: number,
   emptyTableaus: number,
 ): number {
@@ -131,7 +108,12 @@ const DROP_RULES: Record<PileId, (deck: Deck, card: Card) => boolean> =
       pileId,
       (deck: Deck, card: Card) => {
         const stack = getCardsStartingFrom(deck, card);
-        if (stack.length > calculateMaxMoveSize(deck, [pileId])) return false;
+        const emptyCells = filterEmptyPiles(deck, CELL_PILES);
+        const availableTableaus = filterEmptyPiles(
+          deck,
+          TABLEAU_PILES.filter((pile) => pile !== pileId),
+        );
+        if (stack.length > calculateMaxMoveSize(emptyCells.length, availableTableaus.length)) return false;
 
         const resultingPile = [...getCardsInPile(deck, pileId), ...stack];
         const activeSequence = resultingPile.slice(-stack.length - 1);
@@ -163,7 +145,12 @@ const DRAG_RULES: Record<PileId, (deck: Deck, card: Card) => boolean> =
       pileId,
       (deck: Deck, card: Card) => {
         const stack = getCardsStartingFrom(deck, card);
-        if (stack.length > calculateMaxMoveSize(deck, [pileId])) return false;
+        const emptyCells = filterEmptyPiles(deck, CELL_PILES);
+        const availableTableaus = filterEmptyPiles(
+          deck,
+          TABLEAU_PILES.filter((pile) => pile !== pileId),
+        );
+        if (stack.length > calculateMaxMoveSize(emptyCells.length, availableTableaus.length)) return false;
 
         return isFollowingRules(
           stack.map((c) => c.data),

--- a/src/phaser/game/input/CardInteraction.ts
+++ b/src/phaser/game/input/CardInteraction.ts
@@ -123,7 +123,6 @@ function dropCardInNewPile(
       );
     }),
   );
-  deck.executeCardMoveSequence(moveSequence);
   moveHistory.push(moveSequence);
 }
 
@@ -157,6 +156,5 @@ function snapCardToFoundationPile(
       newPilePosition.position,
     ),
   ]);
-  deck.executeCardMoveSequence(moveSequence);
   moveHistory.push(moveSequence);
 }

--- a/src/phaser/game/state/GameState.ts
+++ b/src/phaser/game/state/GameState.ts
@@ -40,7 +40,7 @@ export default class GameState extends Phaser.Scene {
     // Create deck
     const deckModel = createDeck();
     this.deck = new DeckController(this, deckModel);
-    // this.deck.shuffleCards(476); // TODO add shuffle back
+    this.deck.shuffleCards(476);
     this.deck.dealCards();
 
     // Create piles

--- a/src/phaser/game/state/GameState.ts
+++ b/src/phaser/game/state/GameState.ts
@@ -10,7 +10,10 @@ import { createDeck } from "@phaser/deck/state/Deck";
 import { PileController } from "@phaser/pile/PileController";
 import { createPile } from "@phaser/pile/state/Pile";
 import { CardMoveSequence } from "@phaser/move/CardMoveSequence";
-import { deriveUndo, expand } from "@phaser/move/domain/CardMoveSequenceLogic";
+import {
+  invertCardMoveSequence,
+  expand,
+} from "@phaser/move/domain/CardMoveSequenceLogic";
 
 const sceneConfig: Phaser.Types.Scenes.SettingsConfig = {
   active: false,
@@ -71,7 +74,7 @@ export default class GameState extends Phaser.Scene {
 
     // Undo commands
     this.moveHistory.subscribe("pop", (move) => {
-      const undo = deriveUndo(move);
+      const undo = invertCardMoveSequence(move);
       this.deck.executeCardMoveSequence(undo);
     });
   }

--- a/src/phaser/game/state/GameState.ts
+++ b/src/phaser/game/state/GameState.ts
@@ -10,7 +10,7 @@ import { createDeck } from "@phaser/deck/state/Deck";
 import { PileController } from "@phaser/pile/PileController";
 import { createPile } from "@phaser/pile/state/Pile";
 import { CardMoveSequence } from "@phaser/move/CardMoveSequence";
-import { deriveUndo } from "@phaser/move/domain/CardMoveSequenceLogic";
+import { deriveUndo, expand } from "@phaser/move/domain/CardMoveSequenceLogic";
 
 const sceneConfig: Phaser.Types.Scenes.SettingsConfig = {
   active: false,
@@ -63,6 +63,12 @@ export default class GameState extends Phaser.Scene {
   }
 
   public createCommandListeners(): void {
+    // Do commands
+    this.moveHistory.subscribe("push", (move) => {
+      const expandedMove = expand(this.deck.model, move);
+      this.deck.executeCardMoveSequenceWithDelay(expandedMove, 150);
+    });
+
     // Undo commands
     this.moveHistory.subscribe("pop", (move) => {
       const undo = deriveUndo(move);

--- a/src/phaser/game/state/GameState.ts
+++ b/src/phaser/game/state/GameState.ts
@@ -37,7 +37,7 @@ export default class GameState extends Phaser.Scene {
     // Create deck
     const deckModel = createDeck();
     this.deck = new DeckController(this, deckModel);
-    this.deck.shuffleCards(476);
+    // this.deck.shuffleCards(476); // TODO add shuffle back
     this.deck.dealCards();
 
     // Create piles

--- a/src/phaser/move/domain/CardMoveSequenceLogic.ts
+++ b/src/phaser/move/domain/CardMoveSequenceLogic.ts
@@ -12,7 +12,7 @@ import {
 import { createCardMove } from "@phaser/move/CardMove";
 import {
   calculateMaxMoveSizeSimple,
-  calculateMinTempTableausSimple,
+  calculateMinTempTableaus,
 } from "@phaser/game/domain/FreecellRules";
 
 /**
@@ -63,7 +63,7 @@ function expandWithTempTableau(
   const [firstStep] = cardMoves.steps;
 
   const emptyCells = filterEmptyPiles(deck, CELL_PILES);
-  const minTempTableaus = calculateMinTempTableausSimple(
+  const minTempTableaus = calculateMinTempTableaus(
     moveSize,
     emptyCells.length,
   );
@@ -175,14 +175,16 @@ function createPileToPileCardMoveSequence(
         fromPile,
         startFromPosition + index,
         toPile,
-        startToPosition + index
-      )
+        startToPosition + index,
+      ),
     );
 
   return createCardMoveSequence(moveSteps);
 }
 
-export function deriveUndo(cardMoves: CardMoveSequence): CardMoveSequence {
+export function invertCardMoveSequence(
+  cardMoves: CardMoveSequence,
+): CardMoveSequence {
   return createCardMoveSequence(
     [...cardMoves.steps]
       .reverse()

--- a/src/phaser/move/domain/CardMoveSequenceLogic.ts
+++ b/src/phaser/move/domain/CardMoveSequenceLogic.ts
@@ -11,7 +11,7 @@ import {
 } from "@phaser/move/CardMoveSequence";
 import { createCardMove } from "@phaser/move/CardMove";
 import {
-  calculateMaxMoveSizeSimple,
+  calculateMaxMoveSize,
   calculateMinTempTableaus,
 } from "@phaser/game/domain/FreecellRules";
 
@@ -67,7 +67,7 @@ function expandWithTempTableau(
     moveSize,
     emptyCells.length,
   );
-  const cardsToTemp = calculateMaxMoveSizeSimple(
+  const cardsToTemp = calculateMaxMoveSize(
     emptyCells.length,
     minTempTableaus - 1,
   );

--- a/src/phaser/move/domain/CardMoveSequenceLogic.ts
+++ b/src/phaser/move/domain/CardMoveSequenceLogic.ts
@@ -1,7 +1,160 @@
+import { CELL_PILES, PileId, TABLEAU_PILES } from "@phaser/constants/table";
+import {
+  filterEmptyPiles,
+  getCardsInPile,
+  getDeckAfterCardMoves,
+} from "@phaser/deck/domain/DeckLogic";
+import { Deck } from "@phaser/deck/state/Deck";
+import { calculateMaxMoveSize } from "@phaser/game/domain/FreecellRules";
 import {
   CardMoveSequence,
   createCardMoveSequence,
 } from "@phaser/move/CardMoveSequence";
+import { createCardMove } from "../CardMove";
+
+/**
+ * Expands a simplified move sequence to include temporary intermediates states.
+ * Assuming same pile card moves will occur by ascending position.
+ * Undefined behavior if the move provided is not legal.
+ */
+export function expand(
+  deck: Deck,
+  cardMoves: CardMoveSequence,
+): CardMoveSequence {
+  const emptyCells = filterEmptyPiles(deck, CELL_PILES);
+  const emptyTableaus = filterEmptyPiles(deck, TABLEAU_PILES);
+  const moveSize = cardMoves.steps.length;
+  const maxMoveSize = calculateMaxMoveSize(deck, []);
+  const maxCellOnlyMoveSize = calculateMaxMoveSize(deck, TABLEAU_PILES);
+
+  if (moveSize > maxMoveSize) {
+    throw new Error(
+      `Cannot expand move sequence: move size (${moveSize}) exceeds max move size (${maxMoveSize}).`,
+    );
+  }
+
+  // 0 Tableaus required (Base case)
+  if (cardMoves.steps.length <= maxCellOnlyMoveSize) {
+    return handleBaseCase(deck, cardMoves);
+    // 1 Tableau required
+  } else if (
+    cardMoves.steps.length <= calculateMaxMoveSize(deck, TABLEAU_PILES.slice(1))
+  ) {
+    let workingDeck = deck;
+    const source = cardMoves.steps[0].fromPile;
+    const target = cardMoves.steps[0].toPile;
+    const tableau = emptyTableaus[0];
+
+    const maxToTableau = expand(
+      deck,
+      createCardMoveSequenceFromDeck(
+        deck,
+        source,
+        tableau,
+        maxCellOnlyMoveSize,
+      ),
+    );
+    workingDeck = getDeckAfterCardMoves(deck, maxToTableau);
+
+    const remainingToTarget = expand(
+      deck,
+      createCardMoveSequenceFromDeck(
+        deck,
+        source,
+        target,
+        moveSize - maxCellOnlyMoveSize,
+      ),
+    );
+    workingDeck = getDeckAfterCardMoves(deck, remainingToTarget);
+
+    // Move tableau to target
+    const tableauToTarget = expand(
+      deck,
+      createCardMoveSequenceFromDeck(
+        deck,
+        tableau,
+        target,
+        maxCellOnlyMoveSize,
+      ),
+    );
+
+    return createCardMoveSequence([
+      ...maxToTableau.steps,
+      ...remainingToTarget.steps,
+      ...tableauToTarget.steps,
+    ]);
+  }
+}
+
+function handleBaseCase(
+  deck: Deck,
+  cardMoves: CardMoveSequence,
+): CardMoveSequence {
+  const emptyCells = filterEmptyPiles(deck, CELL_PILES);
+  const [top, ...children] = cardMoves.steps;
+
+  const childrenToCells = [...children]
+    .reverse()
+    .map((step, i) =>
+      createCardMove(
+        step.card,
+        step.fromPile,
+        step.fromPosition,
+        emptyCells[i],
+        0,
+      ),
+    );
+
+  const topToTarget = createCardMove(
+    top.card,
+    top.fromPile,
+    top.fromPosition,
+    top.toPile,
+    top.toPosition,
+  );
+
+  const childrenToTarget = children.map((step, i) =>
+    createCardMove(
+      step.card,
+      emptyCells[children.length - i - 1],
+      0,
+      step.toPile,
+      step.toPosition,
+    ),
+  );
+
+  return createCardMoveSequence([
+    ...childrenToCells,
+    topToTarget,
+    ...childrenToTarget,
+  ]);
+}
+
+function createCardMoveSequenceFromDeck(
+  deck: Deck,
+  fromPile: PileId,
+  toPile: PileId,
+  count: number,
+): CardMoveSequence {
+  const fromCards = getCardsInPile(deck, fromPile);
+  const toCards = getCardsInPile(deck, toPile);
+
+  const cardsToMove = fromCards.slice(-count); // get last N cards
+  const startFromPosition = fromCards.length - count;
+  const startToPosition = toCards.length;
+
+  const steps = cardsToMove.map((card, i) =>
+    createCardMove(
+      card.data.id,
+      fromPile,
+      startFromPosition + i,
+      toPile,
+      startToPosition + i,
+    ),
+  );
+
+  return createCardMoveSequence(steps);
+}
 
 export function deriveUndo(cardMoves: CardMoveSequence): CardMoveSequence {
   return createCardMoveSequence(

--- a/src/phaser/move/domain/CardMoveSequenceLogic.ts
+++ b/src/phaser/move/domain/CardMoveSequenceLogic.ts
@@ -2,7 +2,7 @@ import { CELL_PILES, PileId, TABLEAU_PILES } from "@phaser/constants/table";
 import {
   filterEmptyPiles,
   getCardsInPile,
-  getDeckAfterCardMoves,
+  applyCardMoves,
 } from "@phaser/deck/domain/DeckLogic";
 import { Deck } from "@phaser/deck/state/Deck";
 import { calculateMaxMoveSize } from "@phaser/game/domain/FreecellRules";
@@ -54,7 +54,7 @@ export function expand(
         maxCellOnlyMoveSize,
       ),
     );
-    workingDeck = getDeckAfterCardMoves(deck, maxToTableau);
+    workingDeck = applyCardMoves(deck, maxToTableau);
 
     const remainingToTarget = expand(
       deck,
@@ -65,7 +65,7 @@ export function expand(
         moveSize - maxCellOnlyMoveSize,
       ),
     );
-    workingDeck = getDeckAfterCardMoves(deck, remainingToTarget);
+    workingDeck = applyCardMoves(deck, remainingToTarget);
 
     // Move tableau to target
     const tableauToTarget = expand(

--- a/src/phaser/move/domain/CardMoveSequenceLogic.ts
+++ b/src/phaser/move/domain/CardMoveSequenceLogic.ts
@@ -74,7 +74,7 @@ function expandWithTempTableau(
 
   const moveToTemp = expand(
     deck,
-    createCardMoveSequenceFromDeck(
+    createPileToPileCardMoveSequence(
       deck,
       firstStep.fromPile,
       tempTableau,
@@ -85,7 +85,7 @@ function expandWithTempTableau(
 
   const moveToTarget = expand(
     deckAfterTemp,
-    createCardMoveSequenceFromDeck(
+    createPileToPileCardMoveSequence(
       deckAfterTemp,
       firstStep.fromPile,
       firstStep.toPile,
@@ -96,7 +96,7 @@ function expandWithTempTableau(
 
   const moveFromTemp = expand(
     deckAfterTarget,
-    createCardMoveSequenceFromDeck(
+    createPileToPileCardMoveSequence(
       deckAfterTarget,
       tempTableau,
       firstStep.toPile,
@@ -155,31 +155,31 @@ function expandWithFreeCells(
   ]);
 }
 
-function createCardMoveSequenceFromDeck(
+function createPileToPileCardMoveSequence(
   deck: Deck,
   fromPile: PileId,
   toPile: PileId,
-  nCardsToMove: number,
+  numCardsToMove: number,
 ): CardMoveSequence {
-  const from = getCardsInPile(deck, fromPile);
-  const to = getCardsInPile(deck, toPile);
+  const sourcePileCards = getCardsInPile(deck, fromPile);
+  const destinationPileCards = getCardsInPile(deck, toPile);
 
-  const startFrom = from.length - nCardsToMove;
-  const startTo = to.length;
+  const startFromPosition = sourcePileCards.length - numCardsToMove;
+  const startToPosition = destinationPileCards.length;
 
-  const steps = from
-    .slice(-nCardsToMove)
-    .map((card, i) =>
+  const moveSteps = sourcePileCards
+    .slice(-numCardsToMove)
+    .map((card, index) =>
       createCardMove(
         card.data.id,
         fromPile,
-        startFrom + i,
+        startFromPosition + index,
         toPile,
-        startTo + i,
-      ),
+        startToPosition + index
+      )
     );
 
-  return createCardMoveSequence(steps);
+  return createCardMoveSequence(moveSteps);
 }
 
 export function deriveUndo(cardMoves: CardMoveSequence): CardMoveSequence {


### PR DESCRIPTION
## Description
We can now expand simplified commands and decompose pile to pile moves into all the intermediate cell and tableau moves.

Fixes #67 

## Type of change
Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

